### PR TITLE
Remove guard

### DIFF
--- a/src/factory/valid-prop.js
+++ b/src/factory/valid-prop.js
@@ -29,7 +29,7 @@ const createValidPropRule = (
       if (attrName === propName) {
         // ensure we are only checking literal prop values
         const attrValue = getLiteralPropValue(node);
-        if (attrValue && !isOneOf(attrValue, validValues)) {
+        if (!isOneOf(attrValue, validValues)) {
           context.report({
             node,
             message: errorMessage,


### PR DESCRIPTION
isOneOf already accepts undefined and but was shortcutting with on an empty string.