### PR TITLE
Support accessibilityRole in has-accessibility-props rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # eslint-plugin-react-native-a11y
 
-Eslint-plugin-react-native-a11y is a collection of React Native specific ESLint rules for identifying accessibility issues. Building upon the foundation set down by eslint-plugin-jsx-a11y, eslint-plugin-react-native-a11y detects a few of the most commonly made accessibility issues found in react native apps. These rules make it easier for your apps to be navigable by users with screen readers. 
+Eslint-plugin-react-native-a11y is a collection of React Native specific ESLint rules for identifying accessibility issues. Building upon the foundation set down by eslint-plugin-jsx-a11y, eslint-plugin-react-native-a11y detects a few of the most commonly made accessibility issues found in react native apps. These rules make it easier for your apps to be navigable by users with screen readers.
 
 ## Installation
 
@@ -58,8 +58,8 @@ Alternatively, you can enable all the recommended rules at once by adding `plugi
 
 ## Supported Rules
 
-- [accessibility-label](docs/rules/accessibility-label.md): Enforce that views that have `accessible={true}`, also have an accessibilityLabel prop
-- [has-accessibility-props](docs/rules/has-accessibility-props.md): Enforce all `<Touchable\*>` components have `accessibilityTraits` and `accessibilityComponentType` props set
+- [accessibility-label](docs/rules/accessibility-label.md): Enforce that views that have `accessible={true}`, also have an `accessibilityLabel` prop
+- [has-accessibility-props](docs/rules/has-accessibility-props.md): Enforce all `<Touchable\*>` components have `accessibilityRole` prop or both `accessibilityTraits` and `accessibilityComponentType` props set
 - [has-valid-accessibility-component-type](docs/rules/has-valid-accessibility-component-type.md): Enforce `accessibilityComponentType` property value is valid
 - [has-valid-accessibility-traits](docs/rules/has-valid-accessibility-traits.md): Enforce `accessibilityTraits` and `accessibilityComponentType` prop values must be valid
 - [has-valid-important-for-accessibility](docs/rules/has-valid-important-for-accessibility.md): Enforce `importantForAccessibility` property value is valid

--- a/__tests__/src/rules/has-accessibility-props-test.js
+++ b/__tests__/src/rules/has-accessibility-props-test.js
@@ -19,7 +19,7 @@ import rule from '../../../src/rules/has-accessibility-props';
 const ruleTester = new RuleTester();
 
 const expectedError = touchable => ({
-  message: `<${touchable}> must have both the accessibilityTraits and accessibilityComponentType prop`,
+  message: `<${touchable}> must have the accessibilityRole prop, or both accessibilityComponentType and accessibilityTraits`,
   type: 'JSXOpeningElement',
 });
 
@@ -51,6 +51,10 @@ ruleTester.run('has-accessibility-props', rule, {
     {
       code:
         '<div><TouchableNativeFeedback accessibilityTraits="none" accessibilityComponentType="none"/></div>;',
+    },
+    {
+      code:
+        '<div><TouchableNativeFeedback accessibilityRole="none"/></div>;',
     },
   ].map(parserOptionsMapper),
   invalid: [

--- a/docs/rules/has-accessibility-props.md
+++ b/docs/rules/has-accessibility-props.md
@@ -1,8 +1,8 @@
 # has-accessibility-props
 
-<Touchable\*> components must have both the accessibilityTraits and accessibilityComponentType props in order to be fully accessibile.
+<Touchable\*> components must have the accessibilityRole prop or both accessibilityTraits and accessibilityComponentType props in order to be fully accessible.
 
-The accessibilityTraits props tells VoiceOver on iOS what kind of element the user has selected. For android, the accessibilityComponentType prop serves a similar purpose, alerting the end user of the type of selected component.
+The accessibilityRole props tells VoiceOver on iOS what kind of element the user has selected.
 
 Touchable components are one of:
 
@@ -15,8 +15,9 @@ Touchable components are one of:
 
 ### References
 
-1.  https://facebook.github.io/react-native/docs/accessibility.html#accessibilitytraits-ios
-2.  https://facebook.github.io/react-native/docs/accessibility.html#accessibilitycomponenttype-android
+1.  https://facebook.github.io/react-native/docs/accessibility.html#accessibilityrole-ios-android
+2.  https://facebook.github.io/react-native/docs/accessibility.html#accessibilitytraits-ios
+3.  https://facebook.github.io/react-native/docs/accessibility.html#accessibilitycomponenttype-android
 
 ## Rule details
 
@@ -26,12 +27,22 @@ This rule takes no arguments.
 
 ```jsx
 <TouchableOpacity
+  accessibilityRole="none"
+/>
+```
+
+```jsx
+<TouchableOpacity
   accessibilityTraits="none"
   accessibilityComponentType="none"
 />
 ```
 
 ### Fail
+
+```jsx
+<TouchableOpacity />
+```
 
 ```jsx
 <TouchableOpacity accessibilityComponentType="none" />

--- a/src/rules/has-accessibility-props.js
+++ b/src/rules/has-accessibility-props.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Enforce all <Touchable*> components have accessibilityTraits and accessibilityComponentType props set
+ * @fileoverview Enforce all <Touchable*> components have accessibilityRole or accessibilityTraits and accessibilityComponentType props set
  * @author Alex Saunders
  * @flow
  */
@@ -9,15 +9,15 @@
 // ----------------------------------------------------------------------------
 
 import type { JSXOpeningElement } from 'ast-types-flow';
-import { hasEveryProp, elementType } from 'jsx-ast-utils';
+import { hasProp, hasEveryProp, elementType } from 'jsx-ast-utils';
 import type { ESLintContext } from '../../flow/eslint';
 import isTouchable from '../util/isTouchable';
 
 function errorMessage(touchable) {
-  return `<${touchable}> must have both the accessibilityTraits and accessibilityComponentType prop`;
+  return `<${touchable}> must have the accessibilityRole prop, or both accessibilityComponentType and accessibilityTraits`;
 }
 
-const reqProps = ['accessibilityTraits', 'accessibilityComponentType'];
+const deprecatedProps = ['accessibilityTraits', 'accessibilityComponentType'];
 
 module.exports = {
   meta: {
@@ -39,7 +39,7 @@ module.exports = {
   create: (context: ESLintContext) => ({
     JSXOpeningElement: (node: JSXOpeningElement) => {
       if (isTouchable(node, context)) {
-        if (!hasEveryProp(node.attributes, reqProps)) {
+        if (!hasProp(node.attributes, 'accessibilityRole') && !hasEveryProp(node.attributes, deprecatedProps)) {
           context.report({
             node,
             message: errorMessage(elementType(node)),


### PR DESCRIPTION
This allows the use of the new `accessibilityRole` prop if the rule `has-accessibility-props` rule is enabled.