### PR TITLE
add maintenance status note to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Eslint-plugin-react-native-a11y is a collection of React Native specific ESLint rules for identifying accessibility issues. Building upon the foundation set down by eslint-plugin-jsx-a11y, eslint-plugin-react-native-a11y detects a few of the most commonly made accessibility issues found in react native apps. These rules make it easier for your apps to be navigable by users with screen readers.
 
+### Maintenance Status: Active
+
+Formidable is actively working on this project, and we expect to continue for work for the foreseeable future. Bug reports, feature requests and pull requests are welcome. 
+
 ## Installation
 
 Install [ESLint](http://eslint.org):

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
+[![Maintenance Status][maintenance-image]](#maintenance-status)
+
 # eslint-plugin-react-native-a11y
 
 Eslint-plugin-react-native-a11y is a collection of React Native specific ESLint rules for identifying accessibility issues. Building upon the foundation set down by eslint-plugin-jsx-a11y, eslint-plugin-react-native-a11y detects a few of the most commonly made accessibility issues found in react native apps. These rules make it easier for your apps to be navigable by users with screen readers.
-
-### Maintenance Status: Active
-
-Formidable is actively working on this project, and we expect to continue for work for the foreseeable future. Bug reports, feature requests and pull requests are welcome. 
 
 ## Installation
 
@@ -105,3 +103,10 @@ This project started as a fork of [eslint-plugin-jsx-a11y](https://github.com/ev
 ## License
 
 eslint-plugin-react-native-a11y is licensed under the [MIT License](LICENSE.md).
+
+### Maintenance Status
+
+**Active:** Formidable is actively working on this project, and we expect to continue for work for the foreseeable future. Bug reports, feature requests and pull requests are welcome. 
+
+[maintenance-image]: https://img.shields.io/badge/maintenance-active-green.svg
+


### PR DESCRIPTION
@alex-saunders We're adding maintenance status to all our OSS. I think this project should be listed as "Active", but if you have no new featured planned for it, we could list it as "Stable" instead. If you think that's more appropriate, please replace the note I've added with:
```
### Maintenance Status

**Stable:** Formidable is not planning to develop any new features for this project. We are still responding to bug reports and security concerns. We are still welcoming PRs for this project, but PRs that include new features should be small and easy to integrate and should not include breaking changes.
```
And change the badge to:

```
[maintenance-image]: https://img.shields.io/badge/maintenance-stable-blue.svg
```


Let me know if you have any questions