### PR TITLE
Ignore Identifier expressions in bool typechecks

### DIFF
--- a/__tests__/src/rules/has-valid-accessibility-ignores-invert-colors-test.js
+++ b/__tests__/src/rules/has-valid-accessibility-ignores-invert-colors-test.js
@@ -57,6 +57,13 @@ ruleTester.run('has-valid-accessibility-ignores-invert-colors', rule, {
           invertableComponents: ['FastImage']
         }
       ]
+    },
+    {
+      code: `const invertColors = true;
+
+             const Component = () => (
+               <Image accessibilityIgnoresInvertColors={invertColors} />
+             );`
     }
   ].map(parserOptionsMapper),
   invalid: [

--- a/__tests__/src/rules/has-valid-accessibility-state-test.js
+++ b/__tests__/src/rules/has-valid-accessibility-state-test.js
@@ -46,6 +46,13 @@ ruleTester.run('has-valid-accessibility-state', rule, {
     {
       code:
         '<TouchableOpacity accessibilityState={{ disabled: true, checked: true }} />;'
+    },
+    {
+      code: `const active = true;
+
+             const Component = () => (
+               <TouchableOpacity accessibilityState={{ selected: active }} />
+             );`
     }
   ].map(parserOptionsMapper),
   invalid: [
@@ -72,6 +79,14 @@ ruleTester.run('has-valid-accessibility-state', rule, {
     {
       code: '<TouchableOpacity accessibilityState={{ foo: "yes" }} />',
       errors: [invalidObjectKey('foo')]
+    },
+    {
+      code: `const active = true;
+
+             const Component = () => (
+               <TouchableOpacity accessibilityState={{ selected: "active" }} />
+             );`,
+      errors: [valueMustBeBoolean('selected')]
     }
   ].map(parserOptionsMapper)
 });

--- a/src/rules/has-valid-accessibility-state.js
+++ b/src/rules/has-valid-accessibility-state.js
@@ -48,9 +48,19 @@ module.exports = {
                 `accessibilityState object: "checked" value is not either a boolean or 'mixed'`
               );
             } else if (key !== 'checked' && typeof value !== 'boolean') {
-              error(
-                `accessibilityState object: "${key}" value is not a boolean`
+              // $FlowFixMe
+              const astObjectProp = node.value.expression.properties.find(
+                // $FlowFixMe
+                f => f.key.name === key
               );
+              // we can't determine the associated value type of an Identifier expression
+              // treat these cases as though they are valid
+              // $FlowFixMe
+              if (astObjectProp && astObjectProp.value.type !== 'Identifier') {
+                error(
+                  `accessibilityState object: "${key}" value is not a boolean`
+                );
+              }
             }
           });
         }

--- a/src/util/isNodePropValueBoolean.js
+++ b/src/util/isNodePropValueBoolean.js
@@ -18,10 +18,18 @@ export default function isattrPropValueBoolean(attr: JSXAttribute): boolean {
     return true;
   }
   // $FlowFixMe
-  if (attr.value.expression.type !== 'Literal') {
+  const { expression } = attr.value;
+
+  if (expression.type === 'Identifier') {
+    // we can't determine the associated value type of an Identifier expression
+    // treat these cases as though they are valid
+    return true;
+  }
+
+  if (expression.type !== 'Literal') {
     // If not a literal, it cannot be a boolean
     return false;
   }
   // $FlowFixMe
-  return typeof attr.value.expression.value === 'boolean';
+  return typeof expression.value === 'boolean';
 }


### PR DESCRIPTION
- closes https://github.com/FormidableLabs/eslint-plugin-react-native-a11y/issues/84

### The Issue

When code like the below is parsed into an AST, an Identifier (like `active` here) is treated as though it were a `string` (vs. a bool) by our current type checks.

```
const active = true;

const Component = () => (
  <TouchableOpacity accessibilityState={{ selected: active }} />
);
```

### Investigation

After asking around some of the other Formidable devs, we collectively concluded that almost all type-checking should be delegated to either Flow or TypeScript.

However, there are still cases where we can reliably detect incorrect usage (even without a static type checker being used).

### Conclusion

This PR attempts to provide a balanced approach, whereby the library still functions the same way in all cases except for when an `Identifier` is encountered.

In these cases, _this library_ will allow any value as valid -- but separate static type checkers should report any misuse.