### PR TITLE
Fix crash in has-valid-accessibility-ignores-invert-colors

### DIFF
--- a/__tests__/src/rules/has-valid-accessibility-ignores-invert-colors-test.js
+++ b/__tests__/src/rules/has-valid-accessibility-ignores-invert-colors-test.js
@@ -68,6 +68,10 @@ ruleTester.run('has-valid-accessibility-ignores-invert-colors', rule, {
   ].map(parserOptionsMapper),
   invalid: [
     {
+      code: '<View accessibilityIgnoresInvertColors="true"></View>',
+      errors: [typeError],
+    },
+    {
       code: '<View accessibilityIgnoresInvertColors={"true"}></View>',
       errors: [typeError],
     },

--- a/src/util/isNodePropValueBoolean.js
+++ b/src/util/isNodePropValueBoolean.js
@@ -13,12 +13,19 @@ export default function isattrPropValueBoolean(attr: JSXAttribute): boolean {
     // Loose check for correct data being passed in to this function
     throw new Error('isattrPropValueBoolean expects a attr object as argument');
   }
-  if (attr.value === null) {
+
+  const { value } = attr;
+
+  if (value === null) {
     // attr.value is null when it is declared as a prop but not equal to anything. This defaults to `true` in JSX
     return true;
   }
-  // $FlowFixMe
-  const { expression } = attr.value;
+
+  if (!value || !value.expression) {
+    return false;
+  }
+
+  const { expression } = value;
 
   if (expression.type === 'Identifier') {
     // we can't determine the associated value type of an Identifier expression


### PR DESCRIPTION
The rule crashed when the prop value was a string like this:

```
accessibilityIgnoresInvertColors="true"
```

Because `expression` is undefined in this case. This was not picked up by Flow, because the line was disabled with a `$FlowFixMe`. 

I have added a test for this case and handled it by returning `false` if there is no expression. The `null` check on line 19 is already handling the shorthand boolean case, so I think it is safe to return false.

And btw: I'm getting a bunch of changes in yarn.lock when running `yarn install`, but I didn't commit it as part of this PR.