### PR TITLE
Feature/add support for custom image module with image alias

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,14 +1,13 @@
 {
   "presets": [
     [
-      "@babel/preset-env", {
+      "@babel/preset-env",
+      {
         "targets": {
           "node": "4"
         }
       }
     ]
   ],
-  "plugins": [
-    "@babel/transform-flow-strip-types",
-  ]
+  "plugins": ["@babel/transform-flow-strip-types"]
 }

--- a/.changeset/funny-socks-collect.md
+++ b/.changeset/funny-socks-collect.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-react-native-a11y': minor
+---
+
+Allow aliasing Images

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Eslint-plugin-react-native-a11y is a collection of React Native specific ESLint 
 ## Setup
 
 ### Pre-Requisites
+
 Before starting, check you already have ESLint as a `devDependency` of your project.
 
 > Projects created using `react-native init` will already have this, but for Expo depending on your template you may need to follow ESLint's [installation instructions](https://eslint.org/docs/user-guide/getting-started#installation-and-usage).
@@ -30,12 +31,12 @@ yarn add eslint-plugin-react-native-a11y --dev
 
 This plugin exposes four recommended configs.
 
-Name|Description
--|-
-basic|Only use basic validation rules common to both iOS & Android
-ios|Use all rules from "basic", plus iOS-specific extras
-android|Use all rules from "basic", plus Android-specific extras
-all|Use all rules from "basic", plus iOS-specific extras, plus Android-specific extras
+| Name    | Description                                                                        |
+| ------- | ---------------------------------------------------------------------------------- |
+| basic   | Only use basic validation rules common to both iOS & Android                       |
+| ios     | Use all rules from "basic", plus iOS-specific extras                               |
+| android | Use all rules from "basic", plus Android-specific extras                           |
+| all     | Use all rules from "basic", plus iOS-specific extras, plus Android-specific extras |
 
 If your project only supports a single platform, you may get the best experience using a platform-specific config. This will both avoid reporting issues which do not affect your platform and also results in slightly faster linting for larger projects.
 
@@ -48,10 +49,7 @@ Add the config you want to use to the `extends` section of your ESLint config us
 
 module.exports = {
   root: true,
-  extends: [
-    '@react-native-community',
-    'plugin:react-native-a11y/ios'
-  ]
+  extends: ['@react-native-community', 'plugin:react-native-a11y/ios'],
 };
 ```
 
@@ -62,12 +60,10 @@ Alternatively if you do not want to use one of the pre-defined configs — or wa
 
 module.exports = {
   root: true,
-  extends: [
-    '@react-native-community',
-  ],
+  extends: ['@react-native-community'],
   rules: {
-    'react-native-a11y/rule-name': 2
-  }
+    'react-native-a11y/rule-name': 2,
+  },
 };
 ```
 
@@ -76,6 +72,7 @@ For more information on configuring behaviour of an individual rule, please refe
 ## Supported Rules
 
 ### Basic
+
 - [has-accessibility-hint](docs/rules/has-accessibility-hint.md): Enforce `accessibilityHint` is used in conjunction with `accessibilityLabel`
 - [has-accessibility-props](docs/rules/has-accessibility-props.md): Enforce that `<Touchable\*>` components only have either the `accessibilityRole` prop or both `accessibilityTraits` and `accessibilityComponentType` props set
 - [has-valid-accessibility-actions](docs/rules/has-valid-accessibility-actions.md): Enforce both `accessibilityActions` and `onAccessibilityAction` props are valid
@@ -89,9 +86,11 @@ For more information on configuring behaviour of an individual rule, please refe
 - [has-valid-accessibility-descriptors](docs/rules/has-valid-accessibility-descriptors.md): Ensures that Touchable* components have appropriate props to communicate with assistive technologies
 
 ### iOS
+
 - [has-valid-accessibility-ignores-invert-colors](docs/rules/has-valid-accessibility-ignores-invert-colors.md): Enforce that certain elements use `accessibilityIgnoresInvertColors` to avoid being inverted by device color settings.
 
 ### Android
+
 - [has-valid-accessibility-live-region](docs/rules/has-valid-accessibility-live-region.md): Enforce `accessibilityLiveRegion` prop values must be valid
 - [has-valid-important-for-accessibility](docs/rules/has-valid-important-for-accessibility.md): Enforce `importantForAccessibility` property value is valid
 

--- a/__tests__/index-test.js
+++ b/__tests__/index-test.js
@@ -22,8 +22,12 @@ describe('all rule files should be exported by the plugin', () => {
 });
 
 describe('configurations', () => {
-  it("should export a 'recommended' configuration", () => {
-    assert(plugin.configs.recommended);
+  const configs = ['basic', 'ios', 'android', 'all'];
+
+  configs.forEach((name) => {
+    it(`should export a '${name}' configuration`, () => {
+      assert(plugin.configs[name]);
+    });
   });
 });
 

--- a/__tests__/src/rules/has-valid-accessibility-ignores-invert-colors-test.js
+++ b/__tests__/src/rules/has-valid-accessibility-ignores-invert-colors-test.js
@@ -15,7 +15,6 @@ import rule from '../../../src/rules/has-valid-accessibility-ignores-invert-colo
 // -----------------------------------------------------------------------------
 // Tests
 // -----------------------------------------------------------------------------
-
 const ruleTester = new RuleTester();
 
 const typeError = {
@@ -29,99 +28,333 @@ const missingPropError = {
   type: 'JSXElement',
 };
 
-ruleTester.run('has-valid-accessibility-ignores-invert-colors', rule, {
-  valid: [
-    { code: '<View accessibilityIgnoresInvertColors></View>;' },
-    { code: '<View accessibilityIgnoresInvertColors={true}></View>' },
-    { code: '<View accessibilityIgnoresInvertColors={false}></View>' },
-    {
-      code: '<ScrollView accessibilityIgnoresInvertColors></ScrollView>',
-    },
-    {
-      code: '<Image accessibilityIgnoresInvertColors />',
-    },
-    {
-      code: '<View accessibilityIgnoresInvertColors><Image /></View>',
-    },
-    {
-      code: '<View accessibilityIgnoresInvertColors><View><Image /></View></View>',
-    },
-    {
-      code: '<View><View /></View>',
-    },
-    {
-      code: '<FastImage accessibilityIgnoresInvertColors />',
-      options: [
-        {
-          invertableComponents: ['FastImage'],
-        },
-      ],
-    },
-    {
-      code: `const invertColors = true;
+describe('verifyReactNativeImage', () => {
+  it('returns true when importing a named export of Image from react-native', () => {
+    expect(
+      rule.functions
+        .verifyReactNativeImage(`import { Text, Image, View } from 'react-native';
+      const Component = () => (
+        <View>
+        <Image />
+        </View>
+        );`)
+    ).toBe(true);
+  });
 
-             const Component = () => (
-               <Image accessibilityIgnoresInvertColors={invertColors} />
-             );`,
+  it('returns false when importing a named export of a Image from any other library', () => {
+    expect(
+      rule.functions
+        .verifyReactNativeImage(`import { Text, Image, View } from './custom-image-component/Image';
+          const Component = () => (
+            <View>
+            <Image />
+            </View>
+            );`)
+    ).toBe(false);
+  });
+
+  /**
+   * Super edge case if someone wants to alias ReactNative.Image as another component like RNImage and imports an Image from './any-library'
+   */
+  it('returns true when provided a named export of Image that is aliased as something from react-native', () => {
+    expect(
+      rule.functions
+        .verifyReactNativeImage(`import { Text, Image as RNImage, View } from 'react-native';
+              const Component = () => (
+                <View>
+                <RNImage />
+                </View>
+                );`)
+    ).toBe(true);
+  });
+});
+
+const validCustomImportTests = [
+  {
+    title: 'does not throw an error with custom Image components',
+    code: `import { Text, Image, View } from './custom-image-component/Image';
+              const Component = () => (
+                <View>
+                  <Image />
+                </View>
+              );`,
+    parserOptions: {
+      sourceType: 'module',
     },
-    {
-      code: `<Image accessibilityIgnoresInvertColors={shouldInvert ? true : false} />`,
+  },
+];
+
+const validCases = [
+  ...validCustomImportTests,
+  { code: '<View accessibilityIgnoresInvertColors></View>;' },
+  { code: '<View accessibilityIgnoresInvertColors={true}></View>' },
+  { code: '<View accessibilityIgnoresInvertColors={false}></View>' },
+  {
+    code: '<ScrollView accessibilityIgnoresInvertColors></ScrollView>',
+  },
+  {
+    code: '<Image accessibilityIgnoresInvertColors />',
+  },
+  {
+    code: '<View accessibilityIgnoresInvertColors><Image /></View>',
+  },
+  {
+    code: '<View accessibilityIgnoresInvertColors><View><Image /></View></View>',
+  },
+  {
+    code: '<View><View /></View>',
+  },
+  {
+    code: '<FastImage accessibilityIgnoresInvertColors />',
+    options: [
+      {
+        invertableComponents: ['FastImage'],
+      },
+    ],
+  },
+  {
+    code: `const invertColors = true;
+
+           const Component = () => (
+             <Image accessibilityIgnoresInvertColors={invertColors} />
+           );`,
+  },
+  {
+    code: `<Image accessibilityIgnoresInvertColors={shouldInvert ? true : false} />`,
+  },
+];
+
+const invalidCustomImport = [
+  {
+    title:
+      'throws a missing prop error for custom components alongside passing Image that is imported from react-native',
+    code: `import {
+    Image,
+    Button,
+    FlatList,
+    Platform,
+    ScrollView,
+    View,
+  } from 'react-native';
+  import FastImage from './components/FastImage'
+  const Component = () => (
+    <View>
+      <FastImage accessibilityIgnoresInvertColors />
+      <Image />
+    </View>
+  );`,
+    errors: [missingPropError],
+    options: [
+      {
+        invertableComponents: ['FastImage'],
+      },
+    ],
+    parserOptions: {
+      sourceType: 'module',
     },
-  ].map(parserOptionsMapper),
-  invalid: [
-    {
-      code: '<View accessibilityIgnoresInvertColors="true"></View>',
-      errors: [typeError],
+  },
+  {
+    title:
+      'throws a missingPropError for invertibleComponents and type error for Image when it is imported from react-native',
+    code: `import {
+    Image,
+    Button,
+    FlatList,
+    Platform,
+    ScrollView,
+    View,
+  } from 'react-native';
+  import FastImage from './components/FastImage'
+  const Component = () => (
+    <View>
+      <FastImage />
+      <Image accessibilityIgnoresInvertColors={'true'} />
+    </View>
+  );`,
+    errors: [missingPropError, typeError],
+    options: [
+      {
+        invertableComponents: ['FastImage'],
+      },
+    ],
+    parserOptions: {
+      sourceType: 'module',
     },
-    {
-      code: '<View accessibilityIgnoresInvertColors={"true"}></View>',
-      errors: [typeError],
+  },
+  {
+    title: 'can throw multiple errors for custom and normal Image components',
+    code: `import {
+    Image,
+    Button,
+    FlatList,
+    Platform,
+    ScrollView,
+    View,
+  } from 'react-native';
+  import FastImage from './components/FastImage'
+  const Component = () => (
+    <View>
+      <FastImage />
+      <FastImage accessibilityIgnoresInvertColors={'true'} />
+      <FastImage accessibilityIgnoresInvertColors={'false'} />
+      <Image />
+      <Image accessibilityIgnoresInvertColors={'true'} />
+      <Image accessibilityIgnoresInvertColors={'false'} />
+    </View>
+  );`,
+    errors: [
+      missingPropError,
+      typeError,
+      typeError,
+      missingPropError,
+      typeError,
+      typeError,
+    ],
+    options: [
+      {
+        invertableComponents: ['FastImage'],
+      },
+    ],
+    parserOptions: {
+      sourceType: 'module',
     },
-    {
-      code: '<View accessibilityIgnoresInvertColors={"False"}></View>',
-      errors: [typeError],
+  },
+  {
+    title: 'should fail',
+    code: `import React from 'react'
+    import { Image } from 'react-native';
+
+    export const RNImage = (props) => <Image source={props.source} />
+    `,
+    errors: [missingPropError],
+    parserOptions: {
+      sourceType: 'module',
     },
-    {
-      code: '<View accessibilityIgnoresInvertColors={0}></View>',
-      errors: [typeError],
+  },
+  {
+    title: 'supports linting module imports',
+    code: `import * as RN from 'react-native';
+  const { Image } = RN;
+  
+  const Component = (props) => (
+    <Image source={props.source} />
+  );
+  `,
+    errors: [missingPropError],
+    parserOptions: {
+      sourceType: 'module',
     },
-    {
-      code: `<View accessibilityIgnoresInvertColors={1}>
-        <Image
-          style={{width: 50, height: 50}}
-          source={{uri: 'https://facebook.github.io/react-native/img/tiny_logo.png'}}
-        />
-      </View>`,
-      errors: [typeError, missingPropError],
+  },
+  {
+    title:
+      'supports linting on Custom Invertable ImageComponents without react-native imported',
+    code: `import { FastImage } from './fast-image'
+  
+  const Component = (props) => (
+    <>
+      <FastImage />
+      <FastImage accessibilityIgnoresInvertColors={'true'} />
+    </>
+  );
+  `,
+    errors: [missingPropError, typeError],
+    parserOptions: {
+      sourceType: 'module',
     },
-    {
-      code: '<View accessibilityIgnoresInvertColors={{enabled: 1}}></View>',
-      errors: [typeError],
-    },
-    {
-      code: '<View accessibilityIgnoresInvertColors={{value: true}}></View>',
-      errors: [typeError],
-    },
-    {
-      code: '<Image />',
-      errors: [missingPropError],
-    },
-    {
-      code: '<View><Image /></View>',
-      errors: [missingPropError],
-    },
-    {
-      code: '<View><View><Image /></View></View>',
-      errors: [missingPropError],
-    },
-    {
-      code: '<FastImage />',
-      errors: [missingPropError],
-      options: [
-        {
-          invertableComponents: ['FastImage'],
-        },
-      ],
-    },
-  ].map(parserOptionsMapper),
+    options: [
+      {
+        invertableComponents: ['FastImage'],
+      },
+    ],
+  },
+];
+
+const invalidCases = [
+  {
+    code: '<View accessibilityIgnoresInvertColors="true"></View>',
+    errors: [typeError],
+  },
+  {
+    code: '<View accessibilityIgnoresInvertColors={"true"}></View>',
+    errors: [typeError],
+  },
+  {
+    code: '<View accessibilityIgnoresInvertColors={"False"}></View>',
+    errors: [typeError],
+  },
+  {
+    code: '<View accessibilityIgnoresInvertColors={0}></View>',
+    errors: [typeError],
+  },
+  {
+    code: `<View accessibilityIgnoresInvertColors={1}>
+      <Image
+        style={{width: 50, height: 50}}
+        source={{uri: 'https://facebook.github.io/react-native/img/tiny_logo.png'}}
+      />
+    </View>`,
+    errors: [typeError, missingPropError],
+  },
+  {
+    code: '<View accessibilityIgnoresInvertColors={{enabled: 1}}></View>',
+    errors: [typeError],
+  },
+  {
+    code: '<View accessibilityIgnoresInvertColors={{value: true}}></View>',
+    errors: [typeError],
+  },
+  {
+    code: '<Image />',
+    errors: [missingPropError],
+  },
+  {
+    code: '<View><Image /></View>',
+    errors: [missingPropError],
+  },
+  {
+    code: '<View><View><Image /></View></View>',
+    errors: [missingPropError],
+  },
+  {
+    code: '<FastImage />',
+    errors: [missingPropError],
+    options: [
+      {
+        invertableComponents: ['FastImage'],
+      },
+    ],
+  },
+  ...invalidCustomImport,
+];
+
+/**
+ * Solution to rule tester's dynamic title issue
+ */
+RuleTester.describe = function (text, method) {
+  RuleTester.testId = 0;
+  RuleTester.it.title = text;
+
+  method.bind({ testId: 0 });
+
+  describe(`${RuleTester.it.title}`, method);
+};
+
+RuleTester.it = function (text, method) {
+  const computedTitle = eval(`${RuleTester.it.title}Cases`)[RuleTester.testId]
+    .title;
+
+  if (computedTitle) {
+    describe(computedTitle, () => {
+      it(text, method);
+    });
+  } else {
+    it(text, method);
+  }
+
+  RuleTester.testId += 1;
+};
+
+ruleTester.run('has-valid-accessibility-ignores-invert-colors', rule, {
+  valid: validCases.map(parserOptionsMapper),
+  invalid: invalidCases.map(parserOptionsMapper),
 });

--- a/__tests__/src/rules/has-valid-accessibility-ignores-invert-colors-test.js
+++ b/__tests__/src/rules/has-valid-accessibility-ignores-invert-colors-test.js
@@ -30,42 +30,43 @@ const missingPropError = {
 
 describe('verifyReactNativeImage', () => {
   it('returns true when importing a named export of Image from react-native', () => {
-    expect(
-      rule.functions
-        .verifyReactNativeImage(`import { Text, Image, View } from 'react-native';
+    const output = rule.functions
+      .verifyReactNativeImage(`import { Text, Image, View } from 'react-native';
+  const Component = () => (
+    <View>
+    <Image />
+    </View>
+    );`);
+
+    expect(output.enableLinting).toBe(true);
+  });
+
+  it('returns false when importing a named export of a Image from any other library', () => {
+    const output = rule.functions
+      .verifyReactNativeImage(`import { Text, Image, View } from './custom-image-component/Image';
       const Component = () => (
         <View>
         <Image />
         </View>
-        );`)
-    ).toBe(true);
-  });
-
-  it('returns false when importing a named export of a Image from any other library', () => {
-    expect(
-      rule.functions
-        .verifyReactNativeImage(`import { Text, Image, View } from './custom-image-component/Image';
-          const Component = () => (
-            <View>
-            <Image />
-            </View>
-            );`)
-    ).toBe(false);
+        );`);
+    expect(output.enableLinting).toBe(false);
   });
 
   /**
    * Super edge case if someone wants to alias ReactNative.Image as another component like RNImage and imports an Image from './any-library'
    */
   it('returns true when provided a named export of Image that is aliased as something from react-native', () => {
-    expect(
-      rule.functions
-        .verifyReactNativeImage(`import { Text, Image as RNImage, View } from 'react-native';
-              const Component = () => (
-                <View>
-                <RNImage />
-                </View>
-                );`)
-    ).toBe(true);
+    const output = rule.functions
+      .verifyReactNativeImage(`import React from 'react'
+    import {Image as RNImage} from 'react-native'
+    
+    const CustomImage = () => {
+      return <RNImage />
+    }
+    
+    export default CustomImage`);
+
+    expect(output.enableLinting).toBe(true);
   });
 });
 
@@ -226,20 +227,6 @@ const invalidCustomImport = [
 
     export const RNImage = (props) => <Image source={props.source} />
     `,
-    errors: [missingPropError],
-    parserOptions: {
-      sourceType: 'module',
-    },
-  },
-  {
-    title: 'supports linting module imports',
-    code: `import * as RN from 'react-native';
-  const { Image } = RN;
-  
-  const Component = (props) => (
-    <Image source={props.source} />
-  );
-  `,
     errors: [missingPropError],
     parserOptions: {
       sourceType: 'module',

--- a/flow/eslint.js
+++ b/flow/eslint.js
@@ -9,5 +9,8 @@ export type ESLintReport = {
 export type ESLintContext = {
   id: string,
   options: Array<Object>,
-  report: ESLintReport => void,
+  report: (ESLintReport) => void,
+  getSourceCode: () => {
+    text: string,
+  },
 };

--- a/src/rules/has-valid-accessibility-ignores-invert-colors.js
+++ b/src/rules/has-valid-accessibility-ignores-invert-colors.js
@@ -32,11 +32,16 @@ const checkParent = ({ openingElement, parent }) => {
   return true;
 };
 
+type VerifyRNImageRes = {
+  enableLinting: boolean,
+  elementsToCheck: string[],
+};
+
 /**
  * @description varifies that the Image asset is imported from 'react-native' otherwise exits linting
  */
-const verifyReactNativeImage = (text: string): boolean => {
-  const res = {
+const verifyReactNativeImage = (text: string): VerifyRNImageRes => {
+  const res: VerifyRNImageRes = {
     enableLinting: true,
     elementsToCheck: defaultInvertableComponents,
   };

--- a/src/util/isTouchable.js
+++ b/src/util/isTouchable.js
@@ -24,6 +24,9 @@ export default function isTouchable(
     id: '',
     options: [],
     report: () => {},
+    getSourceCode: () => ({
+      text: '',
+    }),
   }
 ) {
   const { options } = context;


### PR DESCRIPTION
In response to #92 

## Use case:

- As a developer I want the option to alias Image and not run into A11y errors for Image components that already use A11y.

Example:
```javascript
import Image from 'components/Image/Image'

const Component = (props: SomeProps) => (
<>
  <Image {...props} /> // could have props passing through or could be all defaulted inside components/Image/Image
</>
)
```
Sample image component
```javascript
import { Image } from 'react-native'

const RNImage = (props) => (
  <Image source={props.source} /> // this component will throw the error for has-valid-accessibility-ignores-invert-colors
)
```

This PR also support module import linting
```
import * as RN from 'react-native'
const { Image } = RN

const Component = (props: ImageProps) => (
  <Image source={props.source} /> // should fail
)
```

This PR will **not include** resolutions for aliasing named Imports such as
```
import { Image as RNImage } from 'react-native'

const Component = (props: ImageProps) => (
  <RNImage source={props.source} /> // will not throw an error b/c we're looking for 'Image'
)
```
Perhaps this can be handled at a later date...

## Proposal:

Adds ability to check for A11y for `react-native` Images and any Image aliased component that are identified. Otherwise the linter will not check and exists out early.

## Changes:

- Checks for Imports that resolve for react-native and image only otherwise ignores aliased Image components
- Adds ability to alias tests (only for `has-valid-accessibility-ignores-invert-colors` so far) but the boilerplate is there for generation of these labels. To me, it feels much cleaner seeing these use cases cleanly identified in sentences rather than seeing large amounts of JSX. Following this structure you can now add a title to an `it` block instead of it becoming JSX.
- Clean up a failing test from the master branch and add in tests for **basic, ios, android, all** options.

## Demo Tutorial

Run the following commands
1. `rm -rf node_modules` // not necessary but it might be beneficial
1. `yarn cache clean` // essential
1. `yarn add --dev github:FrederickEngelhardt/eslint-plugin-react-native-a11y#v2.01-rc1` // this branch was rebased off this current branch with the `lib/` files built using node 12 and committed to the branch.
1. Confirm that importing a file aliased as Image will not throw any `accessibilityIgnoresInvertColors` errors unless it's imported from `react-native`

## Troubleshooting

- Noting that it was surprisingly time intensive and frustrating getting this repo working for debugging locally. I ended up updating the Readme with a quick tutorial for others.
- Main issue was yarn cache, it was caching the previously installed npm module so local files and github repos failed to install correctly resulting in errors finding the plugin (which did exist in node_modules).
- I also updated the `.babelrc` to use node 12. Node 4 seems a bit low for a react-native dependency. Thoughts?

Let me know what you think of this PR. Thanks!