### PR TITLE
Feature/add Include `Pressable` Component on `Touchable`

### DIFF
--- a/__tests__/src/rules/no-nested-touchables-test.js
+++ b/__tests__/src/rules/no-nested-touchables-test.js
@@ -73,5 +73,14 @@ ruleTester.run('no-nested-touchables', rule, {
 ><TouchableOpacity><Text>Nested</Text></TouchableOpacity></TouchableOpacity>`,
       errors: [expectedError],
     },
+    {
+      code: `<TouchableOpacity
+  accessibilityTraits="button"
+  accessibilityComponentType="button"
+  accessibilityLabel="Tap Me!"
+  accessible={true}
+><Pressable><Text>Nested</Text></Pressable></TouchableOpacity>`,
+      errors: [expectedError],
+    },
   ].map(parserOptionsMapper),
 });

--- a/docs/rules/no-nested-touchables.md
+++ b/docs/rules/no-nested-touchables.md
@@ -1,6 +1,6 @@
 # no-nested-touchables
 
-<Touchable*> or <Button /> will not work inside an accessible element. Any element that has the accessible={true} property (along with the accessibleLabel property) must therefore not contain any <Touchable*> or <Button /> elements.
+<Touchable*> and <Pressable /> or <Button /> will not work inside an accessible element. Any element that has the accessible={true} property (along with the accessibleLabel property) must therefore not contain any <Touchable*> and <Pressable /> or <Button /> elements.
 
 ### References
 

--- a/src/util/isTouchable.js
+++ b/src/util/isTouchable.js
@@ -15,6 +15,7 @@ const defaultTouchables = {
   TouchableWithoutFeedback: true,
   TouchableNativeFeedback: true,
   TouchableBounce: true,
+  Pressable: true,
 };
 
 export default function isTouchable(


### PR DESCRIPTION
Since 0.63, the `Pressable` component has been supported, which seems to be a wrapper for` View`, like `Touchable *`.
This PR includes `Pressable` in` Touchable * `and applies the equivalent rules.