### PR TITLE
Allow Eslint 7 as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
 		"jsx-ast-utils": "^3.2.0"
 	},
 	"peerDependencies": {
-		"eslint": "^3 || ^4 || ^5 || ^6"
+		"eslint": "^3 || ^4 || ^5 || ^6 || ^7"
 	},
 	"jest": {
 		"coverageReporters": [


### PR DESCRIPTION
Add Eslint 7 as an allowed peer dependency to remove the following warning:

> warning "eslint-config-react-native-typescript > eslint-plugin-react-native-a11y@2.0.4" has incorrect peer dependency "eslint@^3 || ^4 || ^5 || ^6".

This change doesn't introduce any new warnings when being installed (please ignore the incorrect branch name):
![a screenshot of the console output of running 'yarn' with the changes in this pr](https://user-images.githubusercontent.com/7024578/113515428-634e1400-956c-11eb-87a2-d29195ca7676.png)

I haven't yet tested the package with ESLint 7, but the tests pass successfully except for one:
![a screenshot of the test results from running yarn test. one test is failing.](https://user-images.githubusercontent.com/7024578/113515632-95ac4100-956d-11eb-9a46-47111e36a8cb.png)
It appears the fix for that is included in [this stale PR](https://github.com/FormidableLabs/eslint-plugin-react-native-a11y/pull/93). I don't see any issues that can be caused by looking at the 7.x breaking changes doc available here: https://eslint.org/docs/user-guide/migrating-to-7.0.0.
