### PR TITLE
rules: min tappable area

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,12 @@ yarn add eslint-plugin-react-native-a11y --dev
 
 This plugin exposes four recommended configs.
 
-| Name    | Description                                                                        |
-| ------- | ---------------------------------------------------------------------------------- |
-| basic   | Only use basic validation rules common to both iOS & Android                       |
-| ios     | Use all rules from "basic", plus iOS-specific extras                               |
-| android | Use all rules from "basic", plus Android-specific extras                           |
-| all     | Use all rules from "basic", plus iOS-specific extras, plus Android-specific extras |
+Name|Description
+-|-
+basic|Only use basic validation rules common to both iOS & Android
+ios|Use all rules from "basic", plus iOS-specific extras
+android|Use all rules from "basic", plus Android-specific extras
+all|Use all rules from "basic", plus iOS-specific extras, plus Android-specific extras
 
 If your project only supports a single platform, you may get the best experience using a platform-specific config. This will both avoid reporting issues which do not affect your platform and also results in slightly faster linting for larger projects.
 
@@ -48,7 +48,10 @@ Add the config you want to use to the `extends` section of your ESLint config us
 
 module.exports = {
   root: true,
-  extends: ['@react-native-community', 'plugin:react-native-a11y/ios'],
+  extends: [
+    '@react-native-community',
+    'plugin:react-native-a11y/ios'
+  ]
 };
 ```
 
@@ -59,10 +62,12 @@ Alternatively if you do not want to use one of the pre-defined configs — or wa
 
 module.exports = {
   root: true,
-  extends: ['@react-native-community'],
+  extends: [
+    '@react-native-community'
+  ],
   rules: {
-    'react-native-a11y/rule-name': 2,
-  },
+    'react-native-a11y/rule-name': 2
+  }
 };
 ```
 
@@ -71,7 +76,6 @@ For more information on configuring behaviour of an individual rule, please refe
 ## Supported Rules
 
 ### Basic
-
 - [has-accessibility-hint](docs/rules/has-accessibility-hint.md): Enforce `accessibilityHint` is used in conjunction with `accessibilityLabel`
 - [has-accessibility-props](docs/rules/has-accessibility-props.md): Enforce that `<Touchable\*>` components only have either the `accessibilityRole` prop or both `accessibilityTraits` and `accessibilityComponentType` props set
 - [has-valid-accessibility-actions](docs/rules/has-valid-accessibility-actions.md): Enforce both `accessibilityActions` and `onAccessibilityAction` props are valid
@@ -85,11 +89,9 @@ For more information on configuring behaviour of an individual rule, please refe
 - [has-valid-tappable-area-size](docs/rules/has-valid-tappable-area-size.md): Enforce touchable elements to have a minHeight and minWidth of 44
 
 ### iOS
-
 - [has-valid-accessibility-ignores-invert-colors](docs/rules/has-valid-accessibility-ignores-invert-colors.md): Enforce that certain elements use `accessibilityIgnoresInvertColors` to avoid being inverted by device color settings.
 
 ### Android
-
 - [has-valid-accessibility-live-region](docs/rules/has-valid-accessibility-live-region.md): Enforce `accessibilityLiveRegion` prop values must be valid
 - [has-valid-important-for-accessibility](docs/rules/has-valid-important-for-accessibility.md): Enforce `importantForAccessibility` property value is valid
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Eslint-plugin-react-native-a11y is a collection of React Native specific ESLint 
 ## Setup
 
 ### Pre-Requisites
+
 Before starting, check you already have ESLint as a `devDependency` of your project.
 
 > Projects created using `react-native init` will already have this, but for Expo depending on your template you may need to follow ESLint's [installation instructions](https://eslint.org/docs/user-guide/getting-started#installation-and-usage).
@@ -29,12 +30,12 @@ yarn add eslint-plugin-react-native-a11y --dev
 
 This plugin exposes four recommended configs.
 
-Name|Description
--|-
-basic|Only use basic validation rules common to both iOS & Android
-ios|Use all rules from "basic", plus iOS-specific extras
-android|Use all rules from "basic", plus Android-specific extras
-all|Use all rules from "basic", plus iOS-specific extras, plus Android-specific extras
+| Name    | Description                                                                        |
+| ------- | ---------------------------------------------------------------------------------- |
+| basic   | Only use basic validation rules common to both iOS & Android                       |
+| ios     | Use all rules from "basic", plus iOS-specific extras                               |
+| android | Use all rules from "basic", plus Android-specific extras                           |
+| all     | Use all rules from "basic", plus iOS-specific extras, plus Android-specific extras |
 
 If your project only supports a single platform, you may get the best experience using a platform-specific config. This will both avoid reporting issues which do not affect your platform and also results in slightly faster linting for larger projects.
 
@@ -47,10 +48,7 @@ Add the config you want to use to the `extends` section of your ESLint config us
 
 module.exports = {
   root: true,
-  extends: [
-    '@react-native-community',
-    'plugin:react-native-a11y/ios'
-  ]
+  extends: ['@react-native-community', 'plugin:react-native-a11y/ios'],
 };
 ```
 
@@ -61,12 +59,10 @@ Alternatively if you do not want to use one of the pre-defined configs — or wa
 
 module.exports = {
   root: true,
-  extends: [
-    '@react-native-community',
-  ],
+  extends: ['@react-native-community'],
   rules: {
-    'react-native-a11y/rule-name': 2
-  }
+    'react-native-a11y/rule-name': 2,
+  },
 };
 ```
 
@@ -75,6 +71,7 @@ For more information on configuring behaviour of an individual rule, please refe
 ## Supported Rules
 
 ### Basic
+
 - [has-accessibility-hint](docs/rules/has-accessibility-hint.md): Enforce `accessibilityHint` is used in conjunction with `accessibilityLabel`
 - [has-accessibility-props](docs/rules/has-accessibility-props.md): Enforce that `<Touchable\*>` components only have either the `accessibilityRole` prop or both `accessibilityTraits` and `accessibilityComponentType` props set
 - [has-valid-accessibility-actions](docs/rules/has-valid-accessibility-actions.md): Enforce both `accessibilityActions` and `onAccessibilityAction` props are valid
@@ -85,11 +82,14 @@ For more information on configuring behaviour of an individual rule, please refe
 - [has-valid-accessibility-traits](docs/rules/has-valid-accessibility-traits.md): Enforce `accessibilityTraits` and `accessibilityComponentType` prop values must be valid
 - [has-valid-accessibility-value](docs/rules/has-valid-accessibility-value.md): Enforce `accessibilityValue` property value is valid
 - [no-nested-touchables](docs/rules/no-nested-touchables.md): Enforce if a view has `accessible={true}`, that there are no touchable elements inside
+- [has-valid-tappable-area-size](docs/rules/has-valid-tappable-area-size.md): Enforce touchable elements to have a minHeight and minWidth of 44
 
 ### iOS
+
 - [has-valid-accessibility-ignores-invert-colors](docs/rules/has-valid-accessibility-ignores-invert-colors.md): Enforce that certain elements use `accessibilityIgnoresInvertColors` to avoid being inverted by device color settings.
 
 ### Android
+
 - [has-valid-accessibility-live-region](docs/rules/has-valid-accessibility-live-region.md): Enforce `accessibilityLiveRegion` prop values must be valid
 - [has-valid-important-for-accessibility](docs/rules/has-valid-important-for-accessibility.md): Enforce `importantForAccessibility` property value is valid
 

--- a/__tests__/src/rules/has-valid-tappable-area-size-test.js
+++ b/__tests__/src/rules/has-valid-tappable-area-size-test.js
@@ -1,0 +1,93 @@
+/* eslint-env jest */
+/**
+ * @fileoverview Ensure that all touchables have a min tappable area of 44.
+ * @author Fernanda Toledo
+ */
+
+// -----------------------------------------------------------------------------
+// Requirements
+// -----------------------------------------------------------------------------
+
+import { RuleTester } from 'eslint';
+import parserOptionsMapper from '../../__util__/parserOptionsMapper';
+import rule from '../../../src/rules/has-valid-tappable-area-size';
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+const ruleTester = new RuleTester();
+
+const expectedError = {
+  message: '<TouchableOpacity> must have at least 44 points of size',
+  type: 'JSXOpeningElement',
+};
+
+const secondExpectedError = {
+  message: '<Pressable> must have at least 44 points of size',
+  type: 'JSXOpeningElement',
+};
+
+ruleTester.run('my-new-rule', rule, {
+  valid: [
+    {
+      code: `<TouchableOpacity
+      accessibilityTraits="button"
+      accessibilityComponentType="button"
+      accessibilityLabel="Tap Me!"
+      accessible={true}
+      style={{height: 44, width: 44}}
+    />`,
+    },
+    {
+      code: `<TouchableOpacity
+      accessibilityTraits="button"
+      accessibilityComponentType="button"
+      accessibilityLabel="Tap Me!"
+      accessible={true}
+      style={{height: 60, width: 70}}
+    ><Text>submit</Text><View><Text>cancel</Text></View></TouchableOpacity>`,
+    },
+  ].map(parserOptionsMapper),
+  invalid: [
+    {
+      code: `<TouchableOpacity
+                accessibilityTraits="button"
+                accessibilityComponentType="button"
+                accessibilityLabel="Tap Me!"
+                accessible={true}
+                style={{height: '50%', width: 54}}
+              >
+              </TouchableOpacity>`,
+      errors: [expectedError],
+    },
+    {
+      code: `<TouchableOpacity
+  accessibilityTraits="button"
+  accessibilityComponentType="button"
+  accessibilityLabel="Tap Me!"
+  accessible={true}
+  style={{height: 43, width: 70}}
+></TouchableOpacity>`,
+      errors: [expectedError],
+    },
+    {
+      code: `<TouchableOpacity
+  accessibilityTraits="button"
+  accessibilityComponentType="button"
+  accessibilityLabel="Tap Me!"
+  accessible={true}
+><TouchableOpacity><Text>Nested</Text></TouchableOpacity></TouchableOpacity>`,
+      errors: [expectedError, expectedError],
+    },
+    {
+      code: `<TouchableOpacity
+  accessibilityTraits="button"
+  accessibilityComponentType="button"
+  accessibilityLabel="Tap Me!"
+  accessible={true}
+><Pressable><Text>Nested</Text></Pressable></TouchableOpacity>`,
+      errors: [expectedError, secondExpectedError],
+    },
+  ].map(parserOptionsMapper),
+});

--- a/__tests__/src/rules/has-valid-tappable-area-size-test.js
+++ b/__tests__/src/rules/has-valid-tappable-area-size-test.js
@@ -18,17 +18,27 @@ import rule from '../../../src/rules/has-valid-tappable-area-size';
 
 const ruleTester = new RuleTester();
 
-const expectedError = {
-  message: '<TouchableOpacity> must have at least 44 points of size',
+const touchableHeightError = {
+  message: '<TouchableOpacity> must have a height of at least 44 points',
   type: 'JSXOpeningElement',
 };
 
-const secondExpectedError = {
-  message: '<Pressable> must have at least 44 points of size',
+const touchableWidthError = {
+  message: '<TouchableOpacity> must have a width of at least 44 points',
   type: 'JSXOpeningElement',
 };
 
-ruleTester.run('my-new-rule', rule, {
+const pressableHeightError = {
+  message: '<Pressable> must have a height of at least 44 points',
+  type: 'JSXOpeningElement',
+};
+
+const pressableWidthError = {
+  message: '<Pressable> must have a width of at least 44 points',
+  type: 'JSXOpeningElement',
+};
+
+ruleTester.run('has-valid-size', rule, {
   valid: [
     {
       code: `<TouchableOpacity
@@ -59,7 +69,7 @@ ruleTester.run('my-new-rule', rule, {
                 style={{height: '50%', width: 54}}
               >
               </TouchableOpacity>`,
-      errors: [expectedError],
+      errors: [touchableHeightError],
     },
     {
       code: `<TouchableOpacity
@@ -69,7 +79,7 @@ ruleTester.run('my-new-rule', rule, {
   accessible={true}
   style={{height: 43, width: 70}}
 ></TouchableOpacity>`,
-      errors: [expectedError],
+      errors: [touchableHeightError],
     },
     {
       code: `<TouchableOpacity
@@ -78,7 +88,12 @@ ruleTester.run('my-new-rule', rule, {
   accessibilityLabel="Tap Me!"
   accessible={true}
 ><TouchableOpacity><Text>Nested</Text></TouchableOpacity></TouchableOpacity>`,
-      errors: [expectedError, expectedError],
+      errors: [
+        touchableHeightError,
+        touchableWidthError,
+        touchableHeightError,
+        touchableWidthError,
+      ],
     },
     {
       code: `<TouchableOpacity
@@ -87,7 +102,12 @@ ruleTester.run('my-new-rule', rule, {
   accessibilityLabel="Tap Me!"
   accessible={true}
 ><Pressable><Text>Nested</Text></Pressable></TouchableOpacity>`,
-      errors: [expectedError, secondExpectedError],
+      errors: [
+        touchableHeightError,
+        touchableWidthError,
+        pressableHeightError,
+        pressableWidthError,
+      ],
     },
   ].map(parserOptionsMapper),
 });

--- a/docs/rules/has-valid-tappable-area-size.md
+++ b/docs/rules/has-valid-tappable-area-size.md
@@ -1,0 +1,59 @@
+# has-valid-tappable-area-size
+
+Enforce that <Touchable\*> components comply with the minimum [Target Size Area specified in the WCAG](https://www.w3.org/WAI/WCAG21/Understanding/target-size.html).
+
+In case that porcentual values are being used to determine the height and width, even if they're higher than 44px still the linter will demand to explicitly specify the minHeight and minWidth.
+
+Touchable components are one of:
+
+- `TouchableOpacity`
+- `TouchableHighlight`
+- `TouchableWithoutFeedback`
+- `TouchableNativeFeedback`
+- `TouchableBounce`
+- `Touchable` (from [react-native-platform-touchable](https://github.com/react-community/react-native-platform-touchable))
+
+### References
+
+1. [Apple Human Interface Guidelines](https://developer.apple.com/design/human-interface-guidelines/ios/visual-design/adaptivity-and-layout/)
+2. [Android accessibility help](https://support.google.com/accessibility/android/answer/7101858?hl=en)
+3. [Target Size Area specified in the WCAG](https://www.w3.org/WAI/WCAG21/Understanding/target-size.html)
+
+
+## Rule details
+
+This rule takes no arguments.
+
+### Succeed
+```jsx
+<TouchableOpacity
+  style={{width: 44, height: 44}}
+/>
+```
+
+```jsx
+<TouchableOpacity
+  style={{minWidth: 44, minHeight: 44, width: '50%', alignSelf: 'stretch'}}
+/>
+```
+```jsx
+<TouchableOpacity
+  style={{minWidth: 44, minHeight: 44, flex: 1}}
+/>
+```
+
+### Fail
+
+```jsx
+<TouchableOpacity />
+```
+```jsx
+<TouchableOpacity
+  style={{minWidth: 44, flex: 1}}
+/>
+```
+```jsx
+<TouchableOpacity
+  style={{width: '100%', height: '100%'}}
+/>
+```

--- a/docs/rules/has-valid-tappable-area-size.md
+++ b/docs/rules/has-valid-tappable-area-size.md
@@ -2,7 +2,11 @@
 
 Enforce that <Touchable\*> components comply with the minimum [Target Size Area specified in the WCAG](https://www.w3.org/WAI/WCAG21/Understanding/target-size.html).
 
-In case that porcentual values are being used to determine the height and width, even if they're higher than 44px still the linter will demand to explicitly specify the minHeight and minWidth.
+The way the rule works is by requiring a `minWidth` and `minHeight` for the `<Touchable />` components.
+
+In case that porcentual values are being used to determine the height and width, even if they're higher than 44 points, the linter will still enforce that the `minHeight` and `minWidth` are explicitly specified.
+
+For that reason and to not have to apply these properties to your touchables each time. We recommend having a base touchable component that has these style rules.
 
 Touchable components are one of:
 
@@ -19,27 +23,24 @@ Touchable components are one of:
 2. [Android accessibility help](https://support.google.com/accessibility/android/answer/7101858?hl=en)
 3. [Target Size Area specified in the WCAG](https://www.w3.org/WAI/WCAG21/Understanding/target-size.html)
 
-
 ## Rule details
 
 This rule takes no arguments.
 
 ### Succeed
+
 ```jsx
-<TouchableOpacity
-  style={{width: 44, height: 44}}
-/>
+<TouchableOpacity style={{ width: 44, height: 44 }} />
 ```
 
 ```jsx
 <TouchableOpacity
-  style={{minWidth: 44, minHeight: 44, width: '50%', alignSelf: 'stretch'}}
+  style={{ minWidth: 44, minHeight: 44, width: '50%', alignSelf: 'stretch' }}
 />
 ```
+
 ```jsx
-<TouchableOpacity
-  style={{minWidth: 44, minHeight: 44, flex: 1}}
-/>
+<TouchableOpacity style={{ minWidth: 44, minHeight: 44, flex: 1 }} />
 ```
 
 ### Fail
@@ -47,13 +48,11 @@ This rule takes no arguments.
 ```jsx
 <TouchableOpacity />
 ```
+
 ```jsx
-<TouchableOpacity
-  style={{minWidth: 44, flex: 1}}
-/>
+<TouchableOpacity style={{ minWidth: 44, flex: 1 }} />
 ```
+
 ```jsx
-<TouchableOpacity
-  style={{width: '100%', height: '100%'}}
-/>
+<TouchableOpacity style={{ width: '100%', height: '100%' }} />
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,7 @@ const basicRules = {
   'react-native-a11y/has-valid-accessibility-traits': 'error',
   'react-native-a11y/has-valid-accessibility-value': 'error',
   'react-native-a11y/no-nested-touchables': 'error',
+  'react-native-a11y/has-valid-tappable-area-size': 'error',
 };
 
 const iOSRules = {
@@ -46,6 +47,7 @@ module.exports = {
     'has-valid-accessibility-value': require('./rules/has-valid-accessibility-value'),
     'has-valid-important-for-accessibility': require('./rules/has-valid-important-for-accessibility'),
     'no-nested-touchables': require('./rules/no-nested-touchables'),
+    'has-valid-tappable-area-size': require('./rules/has-valid-tappable-area-size'),
   },
   configs: {
     basic: {

--- a/src/rules/has-valid-tappable-area-size.js
+++ b/src/rules/has-valid-tappable-area-size.js
@@ -1,0 +1,51 @@
+/**
+ * @fileoverview Ensure that all touchables have a min tappable area of 44.
+ * @author Fernanda Toledo
+ * @flow
+ */
+
+// ----------------------------------------------------------------------------
+// Rule Definition
+// ----------------------------------------------------------------------------
+
+import { getProp, getPropValue, elementType } from 'jsx-ast-utils';
+
+import { generateObjSchema } from '../util/schemas';
+import isTouchable from '../util/isTouchable';
+
+function errorMessage(touchable) {
+  return `<${touchable}> must have at least 44 points of size`;
+}
+
+const MIN_TARGET_SIZE = 44;
+
+const schema = generateObjSchema();
+
+module.exports = {
+  meta: {
+    docs: {},
+    schema: [schema],
+  },
+
+  create: (context) => ({
+    JSXOpeningElement: (node) => {
+      if (isTouchable(node, context)) {
+        const styleProp = getProp(node.attributes, 'style');
+        const style = getPropValue(styleProp) || {};
+        const { height, width, minHeight, minWidth } = style;
+        const heightTooSmall =
+          (Number(height) || 0) < MIN_TARGET_SIZE &&
+          (Number(minHeight) || 0) < MIN_TARGET_SIZE;
+        const widthTooSmall =
+          (Number(width) || 0) < MIN_TARGET_SIZE &&
+          (Number(minWidth) || 0) < MIN_TARGET_SIZE;
+        if (heightTooSmall || widthTooSmall) {
+          context.report({
+            node,
+            message: errorMessage(elementType(node)),
+          });
+        }
+      }
+    },
+  }),
+};

--- a/src/rules/has-valid-tappable-area-size.js
+++ b/src/rules/has-valid-tappable-area-size.js
@@ -36,7 +36,15 @@ const schema = generateObjSchema();
 
 module.exports = {
   meta: {
-    docs: {},
+    docs: {
+      description:
+        'Forbid "pressable" element to have a size smaller than 44 px',
+      category: 'Possible Errors',
+      recommended: true,
+      url:
+        'https://github.com/FormidableLabs/eslint-plugin-react-native-a11y/tree/master/docs/rules/has-valid-tappable-area-size.md',
+    },
+    fixable: null,
     schema: [schema],
   },
 

--- a/src/rules/has-valid-tappable-area-size.js
+++ b/src/rules/has-valid-tappable-area-size.js
@@ -16,18 +16,12 @@ import isTouchable from '../util/isTouchable';
 import type { JSXOpeningElement } from 'ast-types-flow';
 import type { ESLintContext } from '../../flow/eslint';
 
-function errorMessage(touchable, heightTooSmall, widthTooSmall) {
-  if (heightTooSmall && widthTooSmall) {
-    return `<${touchable}> must have a size of at least 44 points x 44 points`;
-  }
+function errorMessageHeightTooSmall(touchable) {
+  return `<${touchable}> must have a height of at least 44 points`;
+}
 
-  if (heightTooSmall) {
-    return `<${touchable}> must have a height of at least 44 points`;
-  }
-
-  if (widthTooSmall) {
-    return `<${touchable}> must have a width of at least 44 points`;
-  }
+function errorMessageWidthTooSmall(touchable) {
+  return `<${touchable}> must have a width of at least 44 points`;
 }
 
 const MIN_TARGET_SIZE = 44;
@@ -63,12 +57,16 @@ module.exports = {
           (Number(width) || 0) < MIN_TARGET_SIZE &&
           (Number(minWidth) || 0) < MIN_TARGET_SIZE;
 
-        if (heightTooSmall || widthTooSmall) {
+        if (heightTooSmall) {
           context.report({
             node,
-            message: errorMessage(elementType(node)),
-            heightTooSmall,
-            widthTooSmall,
+            message: errorMessageHeightTooSmall(elementType(node)),
+          });
+        }
+        if (widthTooSmall) {
+          context.report({
+            node,
+            message: errorMessageWidthTooSmall(elementType(node)),
           });
         }
       }


### PR DESCRIPTION
# New rule: has-valid-tappable-area-size

This rule aims to improve accessibility enforcing developers to add explicit minHeight and minWidth attribute to the styles of touchable components.


### Proposal and possible problems

According to the WCAG, apple human guidelines and android accessibility all touchables should have a tappable area size of at least 44, in both dimensions width and height, hence the proposal of this new rule.

Adds the **has-valid-tappable-area-size** rule to the plugin to check if touchable elements have minHeight and minWidth field in the styles. 

I have my doubts about sharing this rule because a touchable component might have a height and width larger than 44 because of porcentual values or using flexbox, but the eslint warning will come up anyways since it enforces developers to explicitly add the properties minHeight and minWidth with a value larger than 44 to the style. Still, didn't want to miss the opportunity to share the rule with the community and learn your thoughts about it



### References

[has-valid-tappable-area-size readme](https://github.com/FormidableLabs/eslint-plugin-react-native-a11y/compare/master...fernandatoledo:rules/tappable_area?expand=1#diff-35ad48ed8de2ce3ff359da83447dec566f8059d7643aa970416fb86b30aa6da5)

