### PR TITLE
update fixer for has-valid-accessibility-descriptors

### DIFF
--- a/__tests__/src/rules/has-valid-accessibility-descriptors-test.js
+++ b/__tests__/src/rules/has-valid-accessibility-descriptors-test.js
@@ -71,6 +71,9 @@ ruleTester.run('has-valid-accessibility-descriptors', rule, {
               <Text>Back</Text>
              </TouchableOpacity>`,
     },
+    {
+      code: `<TouchableBounce {...props} hostRef={hostRef} />`,
+    },
   ].map(parserOptionsMapper),
   invalid: [
     {
@@ -78,14 +81,14 @@ ruleTester.run('has-valid-accessibility-descriptors', rule, {
               <Text>Back</Text>
              </TouchableOpacity>`,
       errors: [expectedError],
-      output: `<TouchableOpacity accessible={false}>
+      output: `<TouchableOpacity accessibilityRole="button">
               <Text>Back</Text>
              </TouchableOpacity>`,
     },
     {
       code: `<TextInput />`,
       errors: [expectedError],
-      output: `<TextInput accessible={false} />`,
+      output: `<TextInput accessibilityLabel="Text input field" />`,
     },
   ].map(parserOptionsMapper),
 });

--- a/src/rules/has-valid-accessibility-descriptors.js
+++ b/src/rules/has-valid-accessibility-descriptors.js
@@ -19,6 +19,9 @@ const errorMessage =
 
 const schema = generateObjSchema();
 
+const hasSpreadProps = (attributes) =>
+  attributes.some((attr) => attr.type === 'JSXSpreadAttribute');
+
 module.exports = {
   meta: {
     docs: {},
@@ -35,7 +38,8 @@ module.exports = {
             'accessibilityLabel',
             'accessibilityActions',
             'accessible',
-          ])
+          ]) &&
+          !hasSpreadProps(node.attributes)
         ) {
           context.report({
             node,
@@ -44,7 +48,9 @@ module.exports = {
               return fixer.insertTextAfterRange(
                 // $FlowFixMe
                 node.name.range,
-                ' accessible={false}'
+                isTouchable(node, context)
+                  ? ' accessibilityRole="button"'
+                  : ' accessibilityLabel="Text input field"'
               );
             },
           });


### PR DESCRIPTION
- ignore elements with spread props
- change the `--fix` to add either an `accessibilityRole` or `accessibilityLabel` rather than just `accessible={false}`