### PR TITLE
Fix links in has-accessibility-props rule docs

### DIFF
--- a/docs/rules/has-accessibility-props.md
+++ b/docs/rules/has-accessibility-props.md
@@ -15,9 +15,8 @@ Touchable components are one of:
 
 ### References
 
-1. https://facebook.github.io/react-native/docs/accessibility.html#accessibilityrole-ios-android
-2. https://facebook.github.io/react-native/docs/accessibility.html#accessibilitytraits-ios
-3. https://facebook.github.io/react-native/docs/accessibility.html#accessibilitycomponenttype-android
+1. https://reactnative.dev/docs/accessibility#accessibilityrole
+2. https://reactnative.dev/blog/2018/08/13/react-native-accessibility-updates
 
 ## Rule details
 


### PR DESCRIPTION
Previous links end up at a 404 page. The `accessibilityTraits` and `accessibilityComponentType` props are no longer documented in the official docs, so I've replaced their links with a new link to the relevant blog post which explains the API change.