### PR TITLE
Feat: add support for role prop

### DIFF
--- a/__tests__/src/rules/has-valid-accessibility-descriptors-test.js
+++ b/__tests__/src/rules/has-valid-accessibility-descriptors-test.js
@@ -20,7 +20,7 @@ const ruleTester = new RuleTester();
 
 const expectedError = {
   message:
-    'Missing a11y props. Expected one of: accessibilityRole OR BOTH accessibilityLabel + accessibilityHint OR BOTH accessibilityActions + onAccessibilityAction',
+    'Missing a11y props. Expected one of: accessibilityRole OR role OR BOTH accessibilityLabel + accessibilityHint OR BOTH accessibilityActions + onAccessibilityAction',
   type: 'JSXOpeningElement',
 };
 
@@ -28,6 +28,11 @@ ruleTester.run('has-valid-accessibility-descriptors', rule, {
   valid: [
     {
       code: '<View></View>;',
+    },
+    {
+      code: `<Pressable role="button">
+              <Text>Back</Text>
+             </Pressable>`,
     },
     {
       code: `<Pressable accessibilityRole="button">

--- a/src/rules/has-valid-accessibility-descriptors.js
+++ b/src/rules/has-valid-accessibility-descriptors.js
@@ -15,7 +15,7 @@ import isTouchable from '../util/isTouchable';
 import { generateObjSchema } from '../util/schemas';
 
 const errorMessage =
-  'Missing a11y props. Expected one of: accessibilityRole OR BOTH accessibilityLabel + accessibilityHint OR BOTH accessibilityActions + onAccessibilityAction';
+  'Missing a11y props. Expected one of: accessibilityRole OR role OR BOTH accessibilityLabel + accessibilityHint OR BOTH accessibilityActions + onAccessibilityAction';
 
 const schema = generateObjSchema();
 

--- a/src/rules/has-valid-accessibility-descriptors.js
+++ b/src/rules/has-valid-accessibility-descriptors.js
@@ -34,6 +34,7 @@ module.exports = {
       if (isTouchable(node, context) || elementType(node) === 'TextInput') {
         if (
           !hasAnyProp(node.attributes, [
+            'role',
             'accessibilityRole',
             'accessibilityLabel',
             'accessibilityActions',

--- a/src/rules/has-valid-accessibility-role.js
+++ b/src/rules/has-valid-accessibility-role.js
@@ -13,6 +13,9 @@ import createValidPropRule from '../factory/valid-prop';
 const errorMessage = 'accessibilityRole must be one of defined values';
 
 const validValues = [
+  'img',
+  'img button',
+  'img link',
   'togglebutton',
   'adjustable',
   'alert',


### PR DESCRIPTION
Closes https://github.com/FormidableLabs/eslint-plugin-react-native-a11y/issues/151

[role](https://reactnative.dev/docs/accessibility#role) prop has precedence over the [accessibilityRole](https://reactnative.dev/docs/accessibility#accessibilityrole)

This PR will add support for the `role` prop and add tests for it.
