### PR TITLE
Fix: Eslint 9 crash in has-valid-accessibility-ignores-invert-colors

### DIFF
--- a/.changeset/odd-steaks-reply.md
+++ b/.changeset/odd-steaks-reply.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-react-native-a11y': patch
+---
+
+Fix for has-valid-accessibility-ignores-invert-colors with eslint 9

--- a/flow/eslint.js
+++ b/flow/eslint.js
@@ -13,4 +13,7 @@ export type ESLintContext = {
   getSourceCode: () => {
     text: string,
   },
+  sourceCode: {
+    text: string,
+  },
 };

--- a/src/rules/has-valid-accessibility-ignores-invert-colors.js
+++ b/src/rules/has-valid-accessibility-ignores-invert-colors.js
@@ -85,11 +85,11 @@ module.exports = {
     verifyReactNativeImage,
   },
 
-  create: ({ options, report, getSourceCode }: ESLintContext) => {
+  create: ({ options, report, getSourceCode, sourceCode }: ESLintContext) => {
     /**
      * Checks to see if there are valid imports and if so verifies that those imports related to 'react-native' or if a custom module exists
      * */
-    const { text } = getSourceCode();
+    const { text } = sourceCode || getSourceCode();
     const { enableLinting, elementsToCheck } = verifyReactNativeImage(text);
 
     // Add in any other invertible components to check for

--- a/src/util/isTouchable.js
+++ b/src/util/isTouchable.js
@@ -27,6 +27,9 @@ export default function isTouchable(
     getSourceCode: () => ({
       text: '',
     }),
+    sourceCode: {
+      text: '',
+    },
   }
 ) {
   const { options } = context;


### PR DESCRIPTION
Use sourceCode by default instead of deprecated getSourceCode to resolve a crash with eslint 9

<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/.github/blob/master/CODE_OF_CONDUCT.md

-->

### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #161

#### Type of Change

<!-- Please delete options that are not relevant (including this descriptive text). -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

### Checklist: (Feel free to delete this section upon completion)

- [x] I have included a changeset if this change will require a version change to one of the packages.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have run all builds, tests, and linting and all checks pass
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
