### PR TITLE
Disable mandatory a11y hint

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ const defaultConfig = {
 };
 
 const basicRules = {
-  'react-native-a11y/has-accessibility-hint': 'error',
+  'react-native-a11y/has-accessibility-hint': 'off',
   'react-native-a11y/has-accessibility-props': 'error',
   'react-native-a11y/has-valid-accessibility-actions': 'error',
   'react-native-a11y/has-valid-accessibility-component-type': 'error',


### PR DESCRIPTION
### Description

Accessibility hint should be provided only when the results of an action are not evident from the element’s label. 

#### Type of Change

<!-- Please delete options that are not relevant (including this descriptive text). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

### Checklist: (Feel free to delete this section upon completion)

- [ ] I have included a changeset if this change will require a version change to one of the packages.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have run all builds, tests, and linting and all checks pass
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
